### PR TITLE
Add live conversation option and update default LLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+logs/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # AIgentChat-Dspy-
-Chat simulation on Dspy
+
+Simple chat simulation using LangChain and Dspy.
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Set your OpenAI API key:
+
+   ```bash
+   export OPENAI_API_KEY=YOUR_KEY
+   ```
+
+3. Run the simulation:
+
+   ```bash
+   python run_simulation.py
+   ```
+
+Logs are saved under the `logs/` directory.
+
+The default LLM model is set to `gpt-4.1-nano`. Set `SHOW_LIVE_CONVERSATIONS = True` in
+`config.py` if you want each conversation turn printed to the terminal while the
+simulation runs.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,37 @@
+# Configuration file containing all tunable parameters and defaults.
+
+# Population Settings
+POPULATION_SIZE = 10
+POPULATION_INSTRUCTION_TEMPLATE_PATH = "templates/population_instruction.txt"
+
+# Wizard Settings
+WIZARD_DEFAULT_GOAL = "Convince population to buy"
+WIZARD_PROMPT_TEMPLATE_PATH = "templates/wizard_prompt.txt"
+MAX_TURNS = 20
+SELF_IMPROVE_AFTER = 10
+SELF_IMPROVE_PROMPT_TEMPLATE_PATH = "templates/self_improve_prompt.txt"
+
+# Judge Settings
+JUDGE_PROMPT_TEMPLATE_PATH = "templates/judge_prompt.txt"
+
+# LLM Hyperparameters
+# Default model to use for all LLM calls
+LLM_MODEL = "gpt-4.1-nano"
+LLM_TEMPERATURE = 0.7
+LLM_MAX_TOKENS = 512
+LLM_TOP_P = 0.9
+
+# File/Logging Settings
+LOGS_DIRECTORY = "logs"
+JSON_INDENT = 2
+
+# Runtime Options
+# Set to True to print conversation turns to the terminal while running
+SHOW_LIVE_CONVERSATIONS = False
+
+# Dspy Settings
+DSPY_TRAINING_ITER = 1
+DSPY_LEARNING_RATE = 0.01
+
+# Miscellaneous
+DEFAULT_TIMEZONE = "UTC"

--- a/god_agent.py
+++ b/god_agent.py
@@ -1,0 +1,44 @@
+"""GodAgent spawns population agents."""
+from __future__ import annotations
+
+import json
+from typing import List
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage, SystemMessage
+
+import config
+import utils
+from population_agent import PopulationAgent
+
+
+class GodAgent:
+    def __init__(self, llm_settings: dict | None = None):
+        self.llm_settings = llm_settings or {
+            "model": config.LLM_MODEL,
+            "temperature": config.LLM_TEMPERATURE,
+            "max_tokens": config.LLM_MAX_TOKENS,
+        }
+        self.llm = ChatOpenAI(
+            model=self.llm_settings["model"],
+            temperature=self.llm_settings["temperature"],
+            max_tokens=self.llm_settings["max_tokens"],
+        )
+        self.template = utils.load_template(config.POPULATION_INSTRUCTION_TEMPLATE_PATH)
+
+    def spawn_population(self, instruction_text: str, n: int | None = None) -> List[PopulationAgent]:
+        n = n or config.POPULATION_SIZE
+        prompt = utils.render_template(self.template, {"instruction": instruction_text, "n": n})
+        messages = [SystemMessage(content=prompt), HumanMessage(content="Provide the JSON array only.")]
+        response = self.llm.invoke(messages).content
+        personas = json.loads(response)
+        population = []
+        for idx, spec in enumerate(personas):
+            agent = PopulationAgent(
+                agent_id=f"Pop_{idx+1:03d}",
+                name=spec.get("name"),
+                personality_description=spec.get("personality"),
+                llm_settings=self.llm_settings,
+            )
+            population.append(agent)
+        return population

--- a/judge_agent.py
+++ b/judge_agent.py
@@ -1,0 +1,33 @@
+"""JudgeAgent evaluates conversation logs."""
+from __future__ import annotations
+
+from typing import Dict
+
+import json
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage, SystemMessage
+
+import config
+import utils
+
+
+class JudgeAgent:
+    def __init__(self, llm_settings: dict | None = None, judge_prompt_template: str | None = None):
+        self.llm_settings = llm_settings or {
+            "model": config.LLM_MODEL,
+            "temperature": 0.3,
+            "max_tokens": config.LLM_MAX_TOKENS,
+        }
+        self.llm = ChatOpenAI(
+            model=self.llm_settings["model"],
+            temperature=self.llm_settings["temperature"],
+            max_tokens=self.llm_settings["max_tokens"],
+        )
+        self.template = judge_prompt_template or utils.load_template(config.JUDGE_PROMPT_TEMPLATE_PATH)
+
+    def assess(self, log: Dict) -> Dict:
+        transcript = "\n".join([f"{t['speaker']}: {t['text']}" for t in log["turns"]])
+        prompt = utils.render_template(self.template, {"goal": log.get("goal"), "transcript": transcript})
+        messages = [SystemMessage(content=prompt), HumanMessage(content="Return JSON with success, score, rationale.")]
+        result = self.llm.invoke(messages).content
+        return json.loads(result)

--- a/population_agent.py
+++ b/population_agent.py
@@ -1,0 +1,51 @@
+"""Defines the PopulationAgent persona."""
+from typing import List, Tuple
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+import config
+import utils
+
+
+class PopulationAgent:
+    """Simple persona-based agent using LangChain for replies."""
+
+    def __init__(self, agent_id: str, name: str, personality_description: str, llm_settings: dict):
+        self.agent_id = agent_id
+        self.name = name
+        self.personality_description = personality_description
+        self.llm_settings = llm_settings
+        self.state = "undecided"
+        self.history: List[Tuple[str, str]] = []  # (speaker, text)
+        self.llm = ChatOpenAI(
+            model=llm_settings.get("model", config.LLM_MODEL),
+            temperature=llm_settings.get("temperature", config.LLM_TEMPERATURE),
+            max_tokens=llm_settings.get("max_tokens", config.LLM_MAX_TOKENS),
+        )
+
+    def respond_to(self, user_message: str) -> str:
+        system_prompt = (
+            f"You are {self.name}. {self.personality_description}. Respond accordingly."
+        )
+        messages = [SystemMessage(content=system_prompt)]
+        for speaker, text in self.history:
+            if speaker == "wizard":
+                messages.append(HumanMessage(content=text))
+            else:
+                messages.append(AIMessage(content=text))
+        messages.append(HumanMessage(content=user_message))
+        response = self.llm.invoke(messages).content
+        self.history.append(("wizard", user_message))
+        self.history.append(("pop", response))
+        return response
+
+    def get_persona(self) -> dict:
+        return {
+            "agent_id": self.agent_id,
+            "name": self.name,
+            "personality_description": self.personality_description,
+        }
+
+    def reset_history(self) -> None:
+        self.history = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+langchain
+langchain-openai
+openai
+dspy

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -1,0 +1,29 @@
+"""Entry point to run the chat simulation."""
+import json
+
+import config
+from god_agent import GodAgent
+from wizard_agent import WizardAgent
+import utils
+
+
+def main():
+    god = GodAgent()
+    population = god.spawn_population("Generate population", config.POPULATION_SIZE)
+    wizard = WizardAgent(wizard_id="Wizard_001")
+    summary = []
+    for pop_agent in population:
+        log = wizard.converse_with(pop_agent, show_live=config.SHOW_LIVE_CONVERSATIONS)
+        filename = f"{wizard.wizard_id}_{pop_agent.agent_id}_{utils.get_timestamp().replace(':', '').replace('-', '')}.json"
+        utils.save_conversation_log(log, filename)
+        summary.append({
+            "pop_agent_id": pop_agent.agent_id,
+            "success": log["judge_result"].get("success"),
+            "score": log["judge_result"].get("score"),
+        })
+    utils.save_conversation_log(summary, "summary.json")
+    print(f"Completed {len(population)} conversations.")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/judge_prompt.txt
+++ b/templates/judge_prompt.txt
@@ -1,0 +1,3 @@
+You are the judge. Given the conversation:
+{{transcript}}
+Did the wizard achieve the goal '{{goal}}'? Respond with JSON {"success": bool, "score": float, "rationale": str}

--- a/templates/population_instruction.txt
+++ b/templates/population_instruction.txt
@@ -1,0 +1,2 @@
+You are God creating {{n}} individuals. Instruction: {{instruction}}.
+Return a JSON array of objects with fields 'name' and 'personality'.

--- a/templates/self_improve_prompt.txt
+++ b/templates/self_improve_prompt.txt
@@ -1,0 +1,2 @@
+Analyze the following logs and suggest improvements to the wizard prompt:
+{{logs}}

--- a/templates/wizard_prompt.txt
+++ b/templates/wizard_prompt.txt
@@ -1,0 +1,2 @@
+You are a persuasive wizard. Your goal is: {{goal}}.
+Engage the population agent in conversation.

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,35 @@
+"""Utility functions for timestamping and file I/O."""
+import json
+import os
+from datetime import datetime, timezone
+
+import config
+
+
+def get_timestamp() -> str:
+    """Return the current UTC timestamp as an ISO 8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_logs_dir():
+    os.makedirs(config.LOGS_DIRECTORY, exist_ok=True)
+
+
+def save_conversation_log(log_obj: dict, filename: str) -> None:
+    """Save a conversation log as JSON under the logs directory."""
+    ensure_logs_dir()
+    path = os.path.join(config.LOGS_DIRECTORY, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(log_obj, f, indent=config.JSON_INDENT)
+
+
+def load_template(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def render_template(template_str: str, variables: dict) -> str:
+    text = template_str
+    for key, val in variables.items():
+        text = text.replace(f"{{{{{key}}}}}", str(val))
+    return text

--- a/wizard_agent.py
+++ b/wizard_agent.py
@@ -1,0 +1,87 @@
+"""WizardAgent interacts with population agents and self-improves."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+import config
+import utils
+from judge_agent import JudgeAgent
+
+# Dspy is imported as placeholder - this code assumes Dspy provides a simple API
+# to fine tune prompts. Replace with actual implementation when available.
+try:
+    import dspy
+except ImportError:  # pragma: no cover - dspy not installed
+    dspy = None
+
+
+class ConversationLog(dict):
+    pass
+
+
+class WizardAgent:
+    def __init__(self, wizard_id: str, goal: str | None = None, llm_settings: dict | None = None):
+        self.wizard_id = wizard_id
+        self.goal = goal or config.WIZARD_DEFAULT_GOAL
+        self.llm_settings = llm_settings or {
+            "model": config.LLM_MODEL,
+            "temperature": config.LLM_TEMPERATURE,
+            "max_tokens": config.LLM_MAX_TOKENS,
+        }
+        self.llm = ChatOpenAI(
+            model=self.llm_settings["model"],
+            temperature=self.llm_settings["temperature"],
+            max_tokens=self.llm_settings["max_tokens"],
+        )
+        self.system_prompt_template = utils.load_template(config.WIZARD_PROMPT_TEMPLATE_PATH)
+        self.current_prompt = utils.render_template(self.system_prompt_template, {"goal": self.goal})
+        self.conversation_count = 0
+        self.history_buffer: List[ConversationLog] = []
+
+    def converse_with(self, pop_agent, show_live: bool = False) -> ConversationLog:
+        log = {
+            "wizard_id": self.wizard_id,
+            "pop_agent_id": pop_agent.agent_id,
+            "goal": self.goal,
+            "turns": [],
+            "timestamp": utils.get_timestamp(),
+        }
+        for _ in range(config.MAX_TURNS):
+            messages = [SystemMessage(content=self.current_prompt)]
+            for t in log["turns"]:
+                if t["speaker"] == "wizard":
+                    messages.append(HumanMessage(content=t["text"]))
+                else:
+                    messages.append(AIMessage(content=t["text"]))
+            wizard_msg = self.llm.invoke(messages).content
+            log["turns"].append({"speaker": "wizard", "text": wizard_msg, "time": utils.get_timestamp()})
+            if show_live:
+                print(f"Wizard: {wizard_msg}")
+            pop_reply = pop_agent.respond_to(wizard_msg)
+            log["turns"].append({"speaker": "pop", "text": pop_reply, "time": utils.get_timestamp()})
+            if show_live:
+                print(f"{pop_agent.name}: {pop_reply}")
+            if self._check_goal(pop_reply):
+                break
+        judge = JudgeAgent()
+        result = judge.assess(log)
+        log["judge_result"] = result
+        self.history_buffer.append(log)
+        self.conversation_count += 1
+        if self.conversation_count % config.SELF_IMPROVE_AFTER == 0:
+            self.self_improve()
+        return log
+
+    def _check_goal(self, text: str) -> bool:
+        return "buy" in text.lower()
+
+    def self_improve(self) -> None:
+        if dspy is None:
+            return
+        # Example placeholder for Dspy improvement routine
+        new_prompt = self.current_prompt + "\n# improved"
+        self.current_prompt = new_prompt
+        self.history_buffer.clear()


### PR DESCRIPTION
## Summary
- default LLM changed to `gpt-4.1-nano`
- configurable option `SHOW_LIVE_CONVERSATIONS` allows printing dialogue during runs
- `wizard_agent` prints each turn when this option is enabled
- `run_simulation` passes through the toggle
- README documents the new model and live output option

## Testing
- `python -m py_compile config.py god_agent.py judge_agent.py population_agent.py run_simulation.py utils.py wizard_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_684134c114b08324a939244937a8ea49