### PR TITLE
Improve realtime logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ The default LLM model is set to `gpt-4.1-nano`. Set `SHOW_LIVE_CONVERSATIONS = T
 `config.py` if you want each conversation turn printed to the terminal while the
 simulation runs.
 
+When a population agent is spawned its specification is immediately written to a
+log file (e.g. `Pop_001_spec_*.json`) so you can inspect it while the
+simulation continues. Prompt improvements made by the wizard are also logged in
+real time with filenames beginning with `improve_`.
+
 ## Summary Output
 
 After running the simulation a `summary.json` file is written under `logs/`.

--- a/god_agent.py
+++ b/god_agent.py
@@ -43,4 +43,10 @@ class GodAgent:
                 llm_settings=self.llm_settings,
             )
             population.append(agent)
+
+            # Save the agent specification immediately so users can inspect it
+            log_filename = f"{agent.agent_id}_spec_{utils.get_timestamp().replace(':', '').replace('-', '')}.json"
+            utils.save_conversation_log(agent.get_spec(), log_filename)
+            print(f"Created {agent.agent_id} -> {log_filename}")
+
         return population

--- a/wizard_agent.py
+++ b/wizard_agent.py
@@ -96,5 +96,6 @@ class WizardAgent:
 
         log_path = f"improve_{utils.get_timestamp().replace(':', '').replace('-', '')}.json"
         utils.save_conversation_log({"prompt": self.current_prompt, "metrics": metrics}, log_path)
+        print(f"Wizard improved prompt saved to {log_path}")
 
         self.history_buffer.clear()


### PR DESCRIPTION
## Summary
- save the specification for each population agent as soon as it is created
- print out path to the spec log file
- show log location after wizard self-improvement
- document realtime logging of specs and improvements

## Testing
- `python -m py_compile god_agent.py wizard_agent.py`
- `python -m py_compile config.py population_agent.py judge_agent.py run_simulation.py wizard_improver.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6841718ee2b0832492f7ad21ccd90cad