### PR TITLE
Fix dataset without explicit score output

### DIFF
--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -41,11 +41,14 @@ if dspy is not None:
             transcript = "\n".join(f"{t['speaker']}: {t['text']}" for t in log.get('turns', []))
             judge = log.get("judge_result", {})
             score = judge.get("score", 0)
-            ex = dspy.Example(
-                logs=f"{transcript}\nRESULT: {judge}",
-                goal=log.get("goal"),
-                score=score,
-            ).with_inputs("logs", "goal").with_outputs("score")
+            ex = (
+                dspy.Example(
+                    logs=f"{transcript}\nRESULT: {judge}",
+                    goal=log.get("goal"),
+                    score=score,
+                )
+                .with_inputs("logs", "goal")
+            )
             dataset.append(ex)
         return dataset
 


### PR DESCRIPTION
## Summary
- ensure dataset examples are created with only inputs specified
- fix `wizard_improver.build_dataset` so examples no longer call `.with_outputs("score")`

## Testing
- `python -m py_compile wizard_improver.py wizard_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68417320e6d08324915173184379727f