### PR TITLE
Add run numbering utilities and agent id format

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,22 @@ wizard optimizer trains on conversation history. If fewer examples are
 available, the system automatically falls back to `dspy.COPRO` for training.
 
 When a population agent is spawned its specification is immediately written to a
-log file (e.g. `Pop_001_spec_*.json`) so you can inspect it while the
+log file (e.g. `1.1_<timestamp>_spec_*.json`) so you can inspect it while the
 simulation continues. Prompt improvements made by the wizard are also logged in
 real time with filenames beginning with `improve_`.
 
+Each invocation of `IntegratedSystem.run` increments `logs/run_counter.txt` and
+agents are labelled using `<run>.<index>_<timestamp>` (e.g. `2.1_20240101T120000Z`).
+
 ## Summary Output
 
-After running the simulation a `summary.json` file is written under `logs/`.
+After running the simulation a `summary_<run>.json` file is written under `logs/`.
 Each entry contains the results for a population agent with the following
 fields:
 
 ```json
 {
-  "pop_agent_id": "Pop_001",
+  "pop_agent_id": "1.1_20240101T120000Z",
   "name": "Alice",
   "personality_description": "eager shopper",
   "system_instruction": "You are Alice. eager shopper. Respond accordingly.",

--- a/god_agent.py
+++ b/god_agent.py
@@ -27,7 +27,7 @@ class GodAgent:
         )
         self.template = utils.load_template(config.POPULATION_INSTRUCTION_TEMPLATE_PATH)
 
-    def spawn_population(self, instruction_text: str, n: int | None = None) -> List[PopulationAgent]:
+    def spawn_population(self, instruction_text: str, n: int | None = None, run_no: int = 0) -> List[PopulationAgent]:
         n = n or config.POPULATION_SIZE
         prompt = utils.render_template(self.template, {"instruction": instruction_text, "n": n})
         messages = [SystemMessage(content=prompt), HumanMessage(content="Provide the JSON array only.")]
@@ -41,7 +41,7 @@ class GodAgent:
         population = []
         for idx, spec in enumerate(personas):
             agent = PopulationAgent(
-                agent_id=f"Pop_{idx+1:03d}",
+                agent_id=utils.format_agent_id(run_no, idx + 1),
                 name=spec.get("name"),
                 personality_description=spec.get("personality"),
                 llm_settings=self.llm_settings,

--- a/integrated_system.py
+++ b/integrated_system.py
@@ -22,11 +22,12 @@ class IntegratedSystem:
         self.wizard = WizardAgent(wizard_id="Wizard_001")
 
     def run(self, instruction: str, n: int) -> None:
-        self.logger.log_event("system_start", instruction=instruction, n=n)
+        run_no = utils.increment_run_number()
+        self.logger.log_event("system_start", instruction=instruction, n=n, run_no=run_no)
         specs = self.generator.generate(instruction, n)
         population: List = []
         for idx, spec in enumerate(specs):
-            agent = self.god.spawn_population(spec.get("personality"), 1)[0]
+            agent = self.god.spawn_population(spec.get("personality"), 1, run_no)[0]
             population.append(agent)
 
         summary: List[dict] = []
@@ -50,8 +51,9 @@ class IntegratedSystem:
                 "conversation_end",
                 pop_agent=pop.agent_id,
                 success=entry["success"],
+                run_no=run_no,
             )
 
-        utils.save_conversation_log(summary, "summary.json")
-        self.logger.log_event("system_end")
+        utils.save_conversation_log(summary, f"summary_{run_no}.json")
+        self.logger.log_event("system_end", run_no=run_no)
         print(f"Completed {len(population)} conversations.")

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,37 @@ def ensure_logs_dir():
     os.makedirs(config.LOGS_DIRECTORY, exist_ok=True)
 
 
+def _run_counter_path() -> str:
+    """Return the path of the run counter file."""
+    ensure_logs_dir()
+    return os.path.join(config.LOGS_DIRECTORY, "run_counter.txt")
+
+
+def get_run_number() -> int:
+    """Return the current run number stored on disk (0 if not found)."""
+    path = _run_counter_path()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return int(fh.read().strip())
+    except Exception:
+        return 0
+
+
+def increment_run_number() -> int:
+    """Increment and persist the run counter, returning the new value."""
+    run_no = get_run_number() + 1
+    path = _run_counter_path()
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(str(run_no))
+    return run_no
+
+
+def format_agent_id(run_no: int, index: int) -> str:
+    """Return a unique agent identifier for the given run and index."""
+    ts = get_timestamp().replace(":", "").replace("-", "")
+    return f"{run_no}.{index}_{ts}"
+
+
 def save_conversation_log(log_obj: dict, filename: str) -> None:
     """Save a conversation log as JSON under the logs directory."""
     ensure_logs_dir()


### PR DESCRIPTION
## Summary
- keep a persistent run counter in `logs/run_counter.txt`
- generate agent ids using `<run>.<index>_<timestamp>`
- pass run number into population generation and logging
- save summaries per run
- document new naming scheme in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684293cc13788324a76cba686fa327cf