### PR TITLE
Fix logging failure on DSPy optimization output

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -20,7 +20,9 @@ def save_conversation_log(log_obj: dict, filename: str) -> None:
     ensure_logs_dir()
     path = os.path.join(config.LOGS_DIRECTORY, filename)
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(log_obj, f, indent=config.JSON_INDENT)
+        # Use default=str so any non-serializable objects are converted to
+        # strings rather than raising an exception.
+        json.dump(log_obj, f, indent=config.JSON_INDENT, default=str)
 
 
 def load_template(path: str) -> str:


### PR DESCRIPTION
## Summary
- serialize arbitrary metric values to string when saving logs

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68429439ff7c8324afb3f75ec5d98869