### PR TITLE
Add improvement log and run tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,26 @@ wizard optimizer trains on conversation history. If fewer examples are
 available, the system automatically falls back to `dspy.COPRO` for training.
 
 When a population agent is spawned its specification is immediately written to a
-log file (e.g. `Pop_001_spec_*.json`) so you can inspect it while the
+log file (e.g. `1.1_<timestamp>_spec_*.json`) so you can inspect it while the
 simulation continues. Prompt improvements made by the wizard are also logged in
 real time with filenames beginning with `improve_`.
+Each improved prompt is additionally appended as a single line to
+`logs/improved_prompts.txt` along with the run number and timestamp.
+
+Each invocation of `IntegratedSystem.run` increments `logs/run_counter.txt` and
+agents are labelled using `<run>.<index>_<timestamp>` (e.g. `2.1_20240101T120000Z`).
+The index increases sequentially for each population agent created during a run
+(`1.1`, `1.2`, ...).
 
 ## Summary Output
 
-After running the simulation a `summary.json` file is written under `logs/`.
+After running the simulation a `summary_<run>.json` file is written under `logs/`.
 Each entry contains the results for a population agent with the following
 fields:
 
 ```json
 {
-  "pop_agent_id": "Pop_001",
+  "pop_agent_id": "1.1_20240101T120000Z",
   "name": "Alice",
   "personality_description": "eager shopper",
   "system_instruction": "You are Alice. eager shopper. Respond accordingly.",

--- a/god_agent.py
+++ b/god_agent.py
@@ -27,7 +27,13 @@ class GodAgent:
         )
         self.template = utils.load_template(config.POPULATION_INSTRUCTION_TEMPLATE_PATH)
 
-    def spawn_population(self, instruction_text: str, n: int | None = None) -> List[PopulationAgent]:
+    def spawn_population(
+        self,
+        instruction_text: str,
+        n: int | None = None,
+        run_no: int = 0,
+        start_index: int = 1,
+    ) -> List[PopulationAgent]:
         n = n or config.POPULATION_SIZE
         prompt = utils.render_template(self.template, {"instruction": instruction_text, "n": n})
         messages = [SystemMessage(content=prompt), HumanMessage(content="Provide the JSON array only.")]
@@ -39,9 +45,9 @@ class GodAgent:
             if personas is None:
                 raise
         population = []
-        for idx, spec in enumerate(personas):
+        for idx, spec in enumerate(personas, start=start_index):
             agent = PopulationAgent(
-                agent_id=f"Pop_{idx+1:03d}",
+                agent_id=utils.format_agent_id(run_no, idx),
                 name=spec.get("name"),
                 personality_description=spec.get("personality"),
                 llm_settings=self.llm_settings,

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,46 @@ def ensure_logs_dir():
     os.makedirs(config.LOGS_DIRECTORY, exist_ok=True)
 
 
+def _run_counter_path() -> str:
+    """Return the path of the run counter file."""
+    ensure_logs_dir()
+    return os.path.join(config.LOGS_DIRECTORY, "run_counter.txt")
+
+
+def get_run_number() -> int:
+    """Return the current run number stored on disk (0 if not found)."""
+    path = _run_counter_path()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return int(fh.read().strip())
+    except Exception:
+        return 0
+
+
+def increment_run_number() -> int:
+    """Increment and persist the run counter, returning the new value."""
+    run_no = get_run_number() + 1
+    path = _run_counter_path()
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(str(run_no))
+    return run_no
+
+
+def format_agent_id(run_no: int, index: int) -> str:
+    """Return a unique agent identifier for the given run and index."""
+    ts = get_timestamp().replace(":", "").replace("-", "")
+    return f"{run_no}.{index}_{ts}"
+
+
+def append_improvement_log(run_no: int, prompt: str) -> None:
+    """Append a single line entry of the improved prompt to a text log."""
+    ensure_logs_dir()
+    path = os.path.join(config.LOGS_DIRECTORY, "improved_prompts.txt")
+    ts = get_timestamp()
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"{ts} run={run_no} prompt={prompt}\n")
+
+
 def save_conversation_log(log_obj: dict, filename: str) -> None:
     """Save a conversation log as JSON under the logs directory."""
     ensure_logs_dir()

--- a/wizard_agent.py
+++ b/wizard_agent.py
@@ -42,6 +42,11 @@ class WizardAgent:
         self.current_prompt = utils.render_template(self.system_prompt_template, {"goal": self.goal})
         self.conversation_count = 0
         self.history_buffer: List[ConversationLog] = []
+        self.current_run_no = 0
+
+    def set_run(self, run_no: int) -> None:
+        """Record the current run number for logging."""
+        self.current_run_no = run_no
 
     def converse_with(self, pop_agent, show_live: bool = False) -> ConversationLog:
 
@@ -100,5 +105,6 @@ class WizardAgent:
         log_path = f"improve_{utils.get_timestamp().replace(':', '').replace('-', '')}.json"
         utils.save_conversation_log({"prompt": self.current_prompt, "metrics": metrics}, log_path)
         print(f"Wizard improved prompt saved to {log_path}")
+        utils.append_improvement_log(self.current_run_no, self.current_prompt)
 
         self.history_buffer.clear()


### PR DESCRIPTION
## Summary
- track each run number and share with WizardAgent
- append improved prompts to `logs/improved_prompts.txt`
- document the improvement log in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684293cc13788324a76cba686fa327cf