### PR TITLE
Bugfix improved prompt logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ real time with filenames beginning with `improve_`.
 
 Each improved prompt is additionally appended to `logs/improved_prompts.txt`
 with the run number and timestamp. Entries are prefixed with
-`instructions=` and long prompts are wrapped every 100 characters for
+`instructions=` and long prompts are wrapped every 150 characters for
 readability.
 
 

--- a/utils.py
+++ b/utils.py
@@ -47,7 +47,7 @@ def format_agent_id(run_no: int, index: int) -> str:
 
 
 
-def _wrap_text(text: str, width: int = 100) -> str:
+def _wrap_text(text: str, width: int = 150) -> str:
     """Return text wrapped with newline every `width` characters."""
     lines = []
     for line in text.splitlines():
@@ -63,7 +63,7 @@ def append_improvement_log(run_no: int, prompt: str) -> None:
     ensure_logs_dir()
     path = os.path.join(config.LOGS_DIRECTORY, "improved_prompts.txt")
     ts = get_timestamp()
-    wrapped = _wrap_text(prompt, 100)
+    wrapped = _wrap_text(prompt, 150)
     with open(path, "a", encoding="utf-8") as fh:
         fh.write(f"{ts} run={run_no} instructions=\"{wrapped}\"\n")
 

--- a/wizard_agent.py
+++ b/wizard_agent.py
@@ -100,7 +100,7 @@ class WizardAgent:
         dataset = build_dataset(self.history_buffer)
         improver, metrics = train_improver(dataset)
 
-        self.current_prompt = improver.agent.signature.instructions
+        self.current_prompt = metrics.get("best_prompt") or improver.agent.signature.instructions
 
         log_path = f"improve_{utils.get_timestamp().replace(':', '').replace('-', '')}.json"
         utils.save_conversation_log({"prompt": self.current_prompt, "metrics": metrics}, log_path)


### PR DESCRIPTION
## Summary
- wrap improved prompts at 150 chars
- parse best instructions from optimizer programs
- log best prompt into `improved_prompts.txt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bdaa67908324a40a22198f3b0438