### PR TITLE
Enhance dataset and training

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,16 @@ The default LLM model is set to `gpt-4o`. Set `SHOW_LIVE_CONVERSATIONS = True` i
 `config.py` if you want each conversation turn printed to the terminal while the
 simulation runs.
 `DSPY_MINIBATCH_SIZE` controls the number of examples used per batch when the
-wizard optimizer trains on conversation history. If fewer examples are
-available, the system automatically falls back to `dspy.COPRO` for training.
+wizard optimizer trains on conversation history.
+When no history is available the wizard still runs `dspy.COPRO` with an empty
+dataset. With only a few examples it uses `BootstrapFewShot` to augment the
+data before training. Once enough examples are collected (>=
+`DSPY_MINIBATCH_SIZE`), it switches to MIPROv2 (`OptimizePrompts`).
+
+Each conversation log now records the wizard's system instruction. The
+optimization dataset therefore pairs that instruction with the conversation
+transcript and the judge's score so the teleprompters can learn which prompts
+lead to better outcomes.
 
 When a population agent is spawned its specification is immediately written to a
 log file (e.g. `1.1_<timestamp>_spec_*.json`) so you can inspect it while the

--- a/wizard_agent.py
+++ b/wizard_agent.py
@@ -55,6 +55,7 @@ class WizardAgent:
             "pop_agent_id": pop_agent.agent_id,
             "pop_agent_spec": pop_agent.get_spec(),
             "goal": self.goal,
+            "prompt": self.current_prompt,
             "turns": [],
             "timestamp": utils.get_timestamp(),
         }
@@ -94,7 +95,7 @@ class WizardAgent:
 
     def self_improve(self) -> None:
         """Train an improver on the conversation history."""
-        if dspy is None or not self.history_buffer:
+        if dspy is None:
             return
 
         dataset = build_dataset(self.history_buffer)


### PR DESCRIPTION
## Summary
- capture the wizard prompt inside each conversation log
- include that prompt when building the DSPy dataset
- update improver signature and training logic
  - empty history uses COPRO
  - few examples bootstrap with `BootstrapFewShot`
  - large datasets continue with MIPROv2
- clarify README about new training flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842b40c5ce483248333ef7e436e7cde