### PR TITLE
Separate logs for improver instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ real time with filenames beginning with `improve_`.
 Each improved prompt is additionally appended to `logs/improved_prompts.txt`
 with the run number and timestamp. Entries are prefixed with
 `instructions=` and long prompts are wrapped every 150 characters for
-readability.
+readability. The prompt improver's own instructions are logged separately
+to `logs/improver_instructions.txt` using the same format.
 
 
 

--- a/utils.py
+++ b/utils.py
@@ -68,6 +68,16 @@ def append_improvement_log(run_no: int, prompt: str) -> None:
         fh.write(f"{ts} run={run_no} instructions=\"{wrapped}\"\n")
 
 
+def append_improver_instruction_log(run_no: int, prompt: str) -> None:
+    """Append the prompt-improver instructions to a separate log."""
+    ensure_logs_dir()
+    path = os.path.join(config.LOGS_DIRECTORY, "improver_instructions.txt")
+    ts = get_timestamp()
+    wrapped = _wrap_text(prompt, 150)
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"{ts} run={run_no} instructions=\"{wrapped}\"\n")
+
+
 
 def save_conversation_log(log_obj: dict, filename: str) -> None:
     """Save a conversation log as JSON under the logs directory."""

--- a/wizard_agent.py
+++ b/wizard_agent.py
@@ -101,7 +101,11 @@ class WizardAgent:
         dataset = build_dataset(self.history_buffer)
         improver, metrics = train_improver(dataset)
 
-        self.current_prompt = metrics.get("best_prompt") or improver.agent.signature.instructions
+        logs_example = dataset[-1].logs if dataset else ""
+        result = improver(instruction=self.current_prompt, logs=logs_example, goal=self.goal)
+        self.current_prompt = getattr(result, "improved_prompt", self.current_prompt)
+        improver_instructions = metrics.get("best_prompt") or improver.agent.signature.instructions
+        utils.append_improver_instruction_log(self.current_run_no, improver_instructions)
 
         log_path = f"improve_{utils.get_timestamp().replace(':', '').replace('-', '')}.json"
         utils.save_conversation_log({"prompt": self.current_prompt, "metrics": metrics}, log_path)


### PR DESCRIPTION
## Summary
- log prompt improver instructions in a new `improver_instructions.txt`
- invoke the trained improver to get an updated wizard prompt
- record improver instructions separately from wizard prompt updates
- document the new log file in the README

## Testing
- `python -m py_compile wizard_agent.py utils.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843165a614083249a7d462d891e10ef