### PR TITLE
Introduce separate minibatch thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ Logs are saved under the `logs/` directory.
 The default LLM model is set to `gpt-4o`. Set `SHOW_LIVE_CONVERSATIONS = True` in
 `config.py` if you want each conversation turn printed to the terminal while the
 simulation runs.
-`DSPY_MINIBATCH_SIZE` controls the number of examples used per batch when the
-wizard optimizer trains on conversation history.
-When no history is available the wizard still runs `dspy.COPRO` with an empty
-dataset. With only a few examples it uses `BootstrapFewShot` to augment the
-data before training. Once enough examples are collected (>=
-`DSPY_MINIBATCH_SIZE`), it switches to MIPROv2 (`OptimizePrompts`).
+`DSPY_COPRO_MINIBATCH_SIZE`, `DSPY_BOOTSRAP_MINIBATCH_SIZE`, and
+`DSPY_MIPRO_MINIBATCH_SIZE` control how many conversation logs trigger each DSPy
+optimizer.
+When the history contains at most `DSPY_COPRO_MINIBATCH_SIZE` examples the
+wizard runs `dspy.COPRO` with an empty dataset. With only a few examples
+(fewer than `DSPY_BOOTSRAP_MINIBATCH_SIZE`) it uses `BootstrapFewShot` to
+augment the data. Once at least `DSPY_BOOTSRAP_MINIBATCH_SIZE` examples are
+available it trains using MIPROv2 (`OptimizePrompts`) with a minibatch size of
+`DSPY_MIPRO_MINIBATCH_SIZE`.
 
 Each conversation log now records the wizard's system instruction. The
 optimization dataset therefore pairs that instruction with the conversation

--- a/config.py
+++ b/config.py
@@ -34,8 +34,10 @@ SHOW_LIVE_CONVERSATIONS = True
 # Dspy Settings
 DSPY_TRAINING_ITER = 1
 DSPY_LEARNING_RATE = 0.01
-# Minimum number of examples per minibatch when training prompts
-DSPY_MINIBATCH_SIZE = 1
+# Optimizer thresholds
+DSPY_COPRO_MINIBATCH_SIZE = 0
+DSPY_BOOTSRAP_MINIBATCH_SIZE = 3
+DSPY_MIPRO_MINIBATCH_SIZE = 30
 # Maximum number of conversation logs kept in memory for self improvement
 HISTORY_BUFFER_LIMIT = 50
 # Maximum conversation history stored by each population agent

--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -116,14 +116,14 @@ if dspy is not None:
             return base + bonus
 
         improver = WizardImprover()
-        if len(dataset) == 0:
+        if len(dataset) <= config.DSPY_COPRO_MINIBATCH_SIZE:
             optimizer = dspy.COPRO(metric=metric)
             trained = optimizer.compile(
                 improver,
                 trainset=dataset,
                 eval_kwargs={"provide_traceback": True},
             )
-        elif len(dataset) < config.DSPY_MINIBATCH_SIZE:
+        elif len(dataset) < config.DSPY_MIPRO_MINIBATCH_SIZE:
             optimizer = dspy.teleprompt.BootstrapFewShot(metric=metric)
             trained = optimizer.compile(
                 improver,
@@ -141,7 +141,7 @@ if dspy is not None:
                 trainset=dataset,
                 num_trials=config.DSPY_TRAINING_ITER,
                 provide_traceback=True,
-                minibatch_size=config.DSPY_MINIBATCH_SIZE,
+                minibatch_size=config.DSPY_MIPRO_MINIBATCH_SIZE,
             )
 
         candidates = getattr(trained, "candidate_programs", [])


### PR DESCRIPTION
## Summary
- add distinct configuration values for COPRO, BootstrapFewShot and MIPROv2
- adjust the wizard improver to reference the new thresholds
- document the new environment variables

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684314b53a7083249833ae58e27f69b5