### PR TITLE
Add method info to prompt improvement logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ simulation continues. Prompt improvements made by the wizard are also logged in
 real time with filenames beginning with `improve_`.
 
 Each improved prompt is additionally appended to `logs/improved_prompts.txt`
-with the run number and timestamp. Entries are prefixed with
-`instructions=` and long prompts are wrapped every 150 characters for
-readability. The prompt improver's own instructions are logged separately
+with the run number, the optimizer method used, and the timestamp.
+Entries are prefixed with `instructions=` and long prompts are wrapped
+every 150 characters for readability. The prompt improver's own
+instructions are logged separately
 to `logs/improver_instructions.txt` using the same format.
 
 

--- a/utils.py
+++ b/utils.py
@@ -58,14 +58,15 @@ def _wrap_text(text: str, width: int = 150) -> str:
     return "\n".join(lines)
 
 
-def append_improvement_log(run_no: int, prompt: str) -> None:
+def append_improvement_log(run_no: int, prompt: str, method: str | None = None) -> None:
     """Append the improved prompt to a persistent text log."""
     ensure_logs_dir()
     path = os.path.join(config.LOGS_DIRECTORY, "improved_prompts.txt")
     ts = get_timestamp()
     wrapped = _wrap_text(prompt, 150)
+    method_part = f" method={method}" if method else ""
     with open(path, "a", encoding="utf-8") as fh:
-        fh.write(f"{ts} run={run_no} instructions=\"{wrapped}\"\n")
+        fh.write(f"{ts} run={run_no}{method_part} instructions=\"{wrapped}\"\n")
 
 
 def append_improver_instruction_log(run_no: int, prompt: str) -> None:

--- a/wizard_agent.py
+++ b/wizard_agent.py
@@ -110,6 +110,6 @@ class WizardAgent:
         log_path = f"improve_{utils.get_timestamp().replace(':', '').replace('-', '')}.json"
         utils.save_conversation_log({"prompt": self.current_prompt, "metrics": metrics}, log_path)
         print(f"Wizard improved prompt saved to {log_path}")
-        utils.append_improvement_log(self.current_run_no, self.current_prompt)
+        utils.append_improvement_log(self.current_run_no, self.current_prompt, metrics.get("method"))
 
         self.history_buffer.clear()

--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -118,6 +118,7 @@ if dspy is not None:
         improver = WizardImprover()
         if len(dataset) <= config.DSPY_COPRO_MINIBATCH_SIZE:
             optimizer = dspy.COPRO(metric=metric)
+            method = "COPRO"
             trained = optimizer.compile(
                 improver,
                 trainset=dataset,
@@ -125,6 +126,7 @@ if dspy is not None:
             )
         elif len(dataset) < config.DSPY_MIPRO_MINIBATCH_SIZE:
             optimizer = dspy.teleprompt.BootstrapFewShot(metric=metric)
+            method = "BootstrapFewShot"
             trained = optimizer.compile(
                 improver,
                 trainset=dataset,
@@ -136,6 +138,7 @@ if dspy is not None:
                 auto=None,
                 verbose=False,
             )
+            method = "MIPROv2"
             trained = optimizer.compile(
                 improver,
                 trainset=dataset,
@@ -156,6 +159,7 @@ if dspy is not None:
             "best_score": best_score,
             "iterations": candidates,
             "best_prompt": best_prompt,
+            "method": method,
         }
         return trained, metrics
 


### PR DESCRIPTION
## Summary
- record which optimizer method (COPRO, BootstrapFewShot, or MIPROv2) generates each improved prompt
- pass this method to improved prompt logs and include description in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68431cec3fb08324a19213198d6c41db