### PR TITLE
Fix MIPRO minibatch error

### DIFF
--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -136,12 +136,19 @@ if dspy is not None:
                 auto=None,
                 verbose=False,
             )
+            # DSPy derives the validation set as 80% of the trainset. When the
+            # dataset is small this can make the validation size smaller than
+            # ``DSPY_MIPRO_MINIBATCH_SIZE`` which causes ``compile`` to raise a
+            # ``ValueError``. Estimate the resulting validation size and cap the
+            # minibatch accordingly so it never exceeds the validation set size.
+            valset_size = int(len(dataset) * 0.8)
+            minibatch = min(config.DSPY_MIPRO_MINIBATCH_SIZE, valset_size)
             trained = optimizer.compile(
                 improver,
                 trainset=dataset,
                 num_trials=config.DSPY_TRAINING_ITER,
                 provide_traceback=True,
-                minibatch_size=config.DSPY_MIPRO_MINIBATCH_SIZE,
+                minibatch_size=minibatch,
             )
 
         candidates = getattr(trained, "candidate_programs", [])


### PR DESCRIPTION
## Summary
- avoid DSPy compile error when the validation set is smaller than configured minibatch size

## Testing
- `python -m py_compile wizard_improver.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68431eada91c832484529b5350c656d6