### PR TITLE
Add flexible self-improvement schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Logs are saved under the `logs/` directory.
 The default LLM model is set to `gpt-4o`. Set `SHOW_LIVE_CONVERSATIONS = True` in
 `config.py` if you want each conversation turn printed to the terminal while the
 simulation runs.
+`SELF_IMPROVE_AFTER` controls when the wizard optimizes its prompt. Provide a
+single integer to run the improver every *n* conversations or a list of counts
+like `[1, 10, 15]` (or the string `"1;10;15"`) to trigger improvements only at
+those points.
 `DSPY_COPRO_MINIBATCH_SIZE`, `DSPY_BOOTSRAP_MINIBATCH_SIZE`, and
 `DSPY_MIPRO_MINIBATCH_SIZE` control how many conversation logs trigger each DSPy
 optimizer.

--- a/config.py
+++ b/config.py
@@ -8,6 +8,12 @@ POPULATION_INSTRUCTION_TEMPLATE_PATH = "templates/population_instruction.txt"
 WIZARD_DEFAULT_GOAL = "Convince population to buy"
 WIZARD_PROMPT_TEMPLATE_PATH = "templates/wizard_prompt.txt"
 MAX_TURNS = 20
+# Trigger the wizard's self-improvement step. Provide an ``int`` to run the
+# improver every ``n`` conversations or a sequence of ints to trigger on
+# specific conversation counts.  For example::
+#
+#     SELF_IMPROVE_AFTER = [1, 10, 15]  # improve after conversations 1, 10 and 15
+#     SELF_IMPROVE_AFTER = 10           # improve after 10, 20, 30, ...
 SELF_IMPROVE_AFTER = 10
 SELF_IMPROVE_PROMPT_TEMPLATE_PATH = "templates/self_improve_prompt.txt"
 


### PR DESCRIPTION
## Summary
- document new self-improvement schedule option in README
- support list or string for `SELF_IMPROVE_AFTER`
- add helper to parse the schedule in `WizardAgent`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684320f421e483248315bacd9a64c667