### PR TITLE
Add dataset size info in improvement log

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ simulation continues. Prompt improvements made by the wizard are also logged in
 real time with filenames beginning with `improve_`.
 
 Each improved prompt is additionally appended to `logs/improved_prompts.txt`
-with the run number, the optimizer method used, and the timestamp.
+with the run number, the conversation count when the improvement occurred,
+the dataset size at that time, the optimizer method used, and the timestamp.
 Entries are prefixed with `instructions=` and long prompts are wrapped
 every 150 characters for readability. The prompt improver's own
 instructions are logged separately

--- a/utils.py
+++ b/utils.py
@@ -58,15 +58,25 @@ def _wrap_text(text: str, width: int = 150) -> str:
     return "\n".join(lines)
 
 
-def append_improvement_log(run_no: int, prompt: str, method: str | None = None) -> None:
+def append_improvement_log(
+    run_no: int,
+    prompt: str,
+    method: str | None = None,
+    conv_no: int | None = None,
+    dataset_size: int | None = None,
+) -> None:
     """Append the improved prompt to a persistent text log."""
     ensure_logs_dir()
     path = os.path.join(config.LOGS_DIRECTORY, "improved_prompts.txt")
     ts = get_timestamp()
     wrapped = _wrap_text(prompt, 150)
     method_part = f" method={method}" if method else ""
+    conv_part = f" conv={conv_no}" if conv_no is not None else ""
+    data_part = f" dataset={dataset_size}" if dataset_size is not None else ""
     with open(path, "a", encoding="utf-8") as fh:
-        fh.write(f"{ts} run={run_no}{method_part} instructions=\"{wrapped}\"\n")
+        fh.write(
+            f"{ts} run={run_no}{conv_part}{data_part}{method_part} instructions=\"{wrapped}\"\n"
+        )
 
 
 def append_improver_instruction_log(run_no: int, prompt: str) -> None:

--- a/wizard_agent.py
+++ b/wizard_agent.py
@@ -121,8 +121,16 @@ class WizardAgent:
         utils.append_improver_instruction_log(self.current_run_no, improver_instructions)
 
         log_path = f"improve_{utils.get_timestamp().replace(':', '').replace('-', '')}.json"
-        utils.save_conversation_log({"prompt": self.current_prompt, "metrics": metrics}, log_path)
+        utils.save_conversation_log(
+            {"prompt": self.current_prompt, "metrics": metrics}, log_path
+        )
         print(f"Wizard improved prompt saved to {log_path}")
-        utils.append_improvement_log(self.current_run_no, self.current_prompt, metrics.get("method"))
+        utils.append_improvement_log(
+            self.current_run_no,
+            self.current_prompt,
+            metrics.get("method"),
+            conv_no=self.conversation_count,
+            dataset_size=len(dataset),
+        )
 
         self.history_buffer.clear()


### PR DESCRIPTION
## Summary
- log dataset size and conversation count whenever a prompt improvement is saved
- mention these new fields in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684324827e0c832483cff8252cbc5d17