### PR TITLE
Fix UnboundLocalError in improver

### DIFF
--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -148,6 +148,7 @@ if dspy is not None:
                 auto=None,
                 verbose=False,
             )
+            method = "MIPROv2"
             # DSPy derives the validation set as 80% of the trainset. When the
             # dataset is small this can make the validation size smaller than
             # ``DSPY_MIPRO_MINIBATCH_SIZE`` which causes ``compile`` to raise a


### PR DESCRIPTION
## Summary
- ensure `method` variable is set when using OptimizePrompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684402220128832492dc0f05e4dc25ef