### PR TITLE
Add schedule validation for population size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ simulation runs.
 `SELF_IMPROVE_AFTER` controls when the wizard optimizes its prompt. Provide a
 single integer to run the improver every *n* conversations or a list of counts
 like `[1, 10, 15]` (or the string `"1;10;15"`) to trigger improvements only at
-those points.
+those points. The configuration checks that `POPULATION_SIZE` is at least as
+large as the final value in this schedule and raises an error otherwise.
 `DSPY_BOOTSRAP_MINIBATCH_SIZE` and `DSPY_MIPRO_MINIBATCH_SIZE` control when each
 DSPy optimizer runs. Once the dataset reaches
 `DSPY_MIPRO_MINIBATCH_SIZE` examples the wizard trains with MIPROv2

--- a/config.py
+++ b/config.py
@@ -1,7 +1,9 @@
 # Configuration file containing all tunable parameters and defaults.
 
 # Population Settings
-POPULATION_SIZE = 10
+# Default population size. The value must be at least as large as the
+# highest value in ``SELF_IMPROVE_AFTER`` when that setting is a sequence.
+POPULATION_SIZE = 36
 POPULATION_INSTRUCTION_TEMPLATE_PATH = "templates/population_instruction.txt"
 
 # Wizard Settings
@@ -14,7 +16,8 @@ MAX_TURNS = 20
 #
 #     SELF_IMPROVE_AFTER = [1, 10, 15]  # improve after conversations 1, 10 and 15
 #     SELF_IMPROVE_AFTER = 10           # improve after 10, 20, 30, ...
-SELF_IMPROVE_AFTER = 10
+# Trigger improvements after conversations 1, 5 and 36 by default.
+SELF_IMPROVE_AFTER = [1, 5, 36]
 SELF_IMPROVE_PROMPT_TEMPLATE_PATH = "templates/self_improve_prompt.txt"
 
 # Judge Settings
@@ -50,3 +53,28 @@ POP_HISTORY_LIMIT = 50
 
 # Miscellaneous
 DEFAULT_TIMEZONE = "UTC"
+
+
+def _get_last_schedule_point(schedule):
+    """Return the last integer from the self-improvement schedule."""
+    if isinstance(schedule, int):
+        return schedule
+    if isinstance(schedule, str):
+        try:
+            points = [int(x) for x in schedule.split(";") if x.strip()]
+        except ValueError:
+            return None
+        return points[-1] if points else None
+    try:
+        points = [int(x) for x in schedule]
+    except (TypeError, ValueError):
+        return None
+    return points[-1] if points else None
+
+
+_last_point = _get_last_schedule_point(SELF_IMPROVE_AFTER)
+if _last_point is not None and POPULATION_SIZE < _last_point:
+    raise ValueError(
+        f"POPULATION_SIZE ({POPULATION_SIZE}) must be at least "
+        f"as large as the last entry in SELF_IMPROVE_AFTER ({_last_point})"
+    )


### PR DESCRIPTION
## Summary
- default population size is 36
- schedule defaults to `[1, 5, 36]`
- validate population size against schedule when loading config
- document the new validation in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68440533f68c83249694a9da519f0d55