### PR TITLE
Fix unexpected keyword argument in COPRO compile

### DIFF
--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -163,7 +163,6 @@ if dspy is not None:
             trained = optimizer.compile(
                 improver_module,
                 trainset=dataset,
-                eval_kwargs={"provide_traceback": True},
             )
 
         candidates = getattr(trained, "candidate_programs", [])


### PR DESCRIPTION
## Summary
- remove unsupported `provide_traceback` argument when using COPRO optimizer

## Testing
- `python -m py_compile wizard_improver.py`
- `python main.py` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68440d8ae61c832497c75f8ddc7b0866