### PR TITLE
Fix missing eval_kwargs for COPRO

### DIFF
--- a/wizard_improver.py
+++ b/wizard_improver.py
@@ -163,6 +163,7 @@ if dspy is not None:
             trained = optimizer.compile(
                 improver_module,
                 trainset=dataset,
+                eval_kwargs={"display_progress": False},
             )
 
         candidates = getattr(trained, "candidate_programs", [])


### PR DESCRIPTION
## Summary
- set `eval_kwargs` when training with COPRO

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844162778e4832481d48680557c0061